### PR TITLE
lib/cluster-store: improved API doc

### DIFF
--- a/lib/cluster-store.js
+++ b/lib/cluster-store.js
@@ -8,20 +8,23 @@ var NativeStore = require('strong-store-cluster');
  * in the master process. The initialization happens when this module
  * is required, thus calling this function is entirely optional.
  */
-function _setup() {
+function setup() {
   // no-op
 }
 
 /**
- * Return the `ClusterStore` extending `socket.io`'s session Store.
+ * Return the `ClusterStore` constructor.
  *
- * @param {Object} io
+ * @param {Object} io socket.io module as returned by `require('socket.io')`
  * @return {function}
  */
 module.exports = function(io) {
 
   /**
    * Initialize ClusterStore with the given `options`.
+   *
+   * ClusterStore is an implementation of socket.io store using node's native
+   * cluster messaging.
    *
    * @param {Object} options
    * @constructor
@@ -51,6 +54,7 @@ module.exports = function(io) {
    * Publish a message to a channel.
    * @param {string} name Channel name.
    * @param {...Object} var_args Message arguments.
+   * @private
    */
   ClusterStore.prototype.publish = function(name) {
     var args = Array.prototype.slice.call(arguments, 1);
@@ -67,6 +71,7 @@ module.exports = function(io) {
    * @param {string} name Channel name.
    * @param {function(...[Object])} consumer Message consumer.
    * @param {function(Error)} fn Callback on done.
+   * @private
    */
   ClusterStore.prototype.subscribe = function(name, consumer, fn) {
     this._subscribers[name] = consumer;
@@ -77,6 +82,7 @@ module.exports = function(io) {
    * Unsubscribe from messages in a channel.
    * @param {string} name Channel name.
    * @param {function(Error|string)} fn Callback on done.
+   * @private
    */
   ClusterStore.prototype.unsubscribe = function(name, fn) {
     delete this._subscribers[name];
@@ -88,6 +94,7 @@ module.exports = function(io) {
    * The handler dispatches the message to the consumer registered
    * for message's channel.
    * @param {{clientId:string, name:string, args:Array}} data
+   * @private
    */
   ClusterStore.prototype._onMessage = function(data) {
     if (data.clientId === this._clientId) return;
@@ -104,6 +111,7 @@ module.exports = function(io) {
    * @param {string} id
    * @constructor
    * @extends {io.Store.Client}
+   * @private
    */
   function ClusterClient(store, id) {
     io.Store.Client.apply(this, arguments);
@@ -115,6 +123,7 @@ module.exports = function(io) {
    * Acquire a keylock or get an already acquired one.
    * Calls `fn` with keylock and hashmap value (client data).
    * @param {function(Error, KeyLock, Object)} fn
+   * @private
    */
   ClusterClient.prototype._getKeylock = function(fn) {
     var self = this;
@@ -139,6 +148,7 @@ module.exports = function(io) {
    * Get the value of a key.
    * @param {string} key
    * @param {function(Error, *)} fn
+   * @private
    */
   ClusterClient.prototype.get = function(key, fn) {
     this._getKeylock(function(err, keylock, hashmap) {
@@ -153,6 +163,7 @@ module.exports = function(io) {
    * @param {string} key
    * @param {*} value
    * @param {function(Error)} fn
+   * @private
    */
   ClusterClient.prototype.set = function(key, value, fn) {
     this._getKeylock(function(err, keylock, hashmap) {
@@ -167,6 +178,7 @@ module.exports = function(io) {
    * Check if there is a value associated with a key.
    * @param {string} key
    * @param {function(Error,boolean)} fn
+   * @private
    */
   ClusterClient.prototype.has = function(key, fn) {
     this._getKeylock(function(err, keylock, hashmap) {
@@ -179,6 +191,7 @@ module.exports = function(io) {
    * Delete a key and it's value.
    * @param {string} key
    * @param {function(Error)} fn
+   * @private
    */
   ClusterClient.prototype.del = function(key, fn) {
     this._getKeylock(function(err, keylock, hashmap) {
@@ -191,6 +204,7 @@ module.exports = function(io) {
   /**
    * Destroy the client.
    * @param {?number} expiration number of seconds to expire client data
+   * @private
    */
   ClusterClient.prototype.destroy = function(expiration) {
     var self = this;
@@ -214,7 +228,11 @@ module.exports = function(io) {
   };
 
   ClusterStore.Client = ClusterClient;
-  ClusterStore.setup = _setup;
+
+  /**
+   * Same as `setup()` (see above).
+   */
+  ClusterStore.setup = setup;
 
   if (cluster.isMaster) {
     // See https://github.com/strongloop/sl-mq/issues/8
@@ -224,4 +242,4 @@ module.exports = function(io) {
   return ClusterStore;
 };
 
-module.exports.setup = _setup;
+module.exports.setup = setup;


### PR DESCRIPTION
Marked most members as private.

Renamed _setup() to setup() so that it can be documented.

Polished text of documentation comments.

See SLN-503.

@sam-github or @chandadharap or @stdarg: Please review.
