### PR TITLE
Enable the master process to connect to the shared store

### DIFF
--- a/lib/cluster-store.js
+++ b/lib/cluster-store.js
@@ -38,7 +38,11 @@ module.exports = function(io) {
     this._pub = this._connection.createPubQueue('socket.io');
     this._sub = this._connection.createSubQueue('socket.io');
     this._sub.subscribe('', this._onMessage.bind(this));
-    this._clientId = cluster.worker.id;
+    if (cluster.isMaster) {
+        this._clientId = 'master';
+    } else {
+        this._clientId = cluster.worker.id;
+    }
     this._subscribers = {};
     this._collection = NativeStore.collection('strong-cluster-socket.io-session-store');
 


### PR DESCRIPTION
I wanted to use an instance of socket.io as a deaf sender (not listening, and able to send out to connected clients across all workers). I therefore wanted to share the store across the forks _and_ the master itself. This fixes an error caused when the master attempts to obtain its ID as if it were a worker.
